### PR TITLE
Redirect to a custom 403 page

### DIFF
--- a/EPFL-Accred.php
+++ b/EPFL-Accred.php
@@ -145,9 +145,11 @@ class Controller
      */
     function get_403_url()
     {
+    	$right = "WordPress.Editor";
+    	
     	$unit_label = $this->settings->get('unit');
     	
-    	$url = "/global-error/403.php?error_type=accred&unit_label=${unit_label}";
+    	$url = "/global-error/403.php?error_type=accred&right=${right}&unit_label=${unit_label}";
     
       return $url;
     }

--- a/EPFL-Accred.php
+++ b/EPFL-Accred.php
@@ -103,7 +103,7 @@ class Controller
 
         if (empty(trim($user_role)) && $user === false) {
             // User unknown and has no role: die() early (don't create it)
-            echo ___("Utilisateur inconnu");
+            header("Location: " . $this->get_403_url());
             die();
         }
 
@@ -135,9 +135,21 @@ class Controller
         if (empty(trim($user_role))) {
             // User with no role, but exists in database: die late
             // (*after* invalidating their rights in the WP database)
-            echo ___("Accès refusé");
+            header("Location: " . $this->get_403_url());
             die();
         }
+    }
+    
+    /**
+     * Returns the URL the user is redirect to for a 403 (access denied) error.
+     */
+    function get_403_url()
+    {
+    	$unit_label = $this->settings->get('unit');
+    	
+    	$url = "/global-error/403.php?error_type=accred&unit_label=${unit_label}";
+    
+      return $url;
     }
 }
 

--- a/EPFL-Accred.php
+++ b/EPFL-Accred.php
@@ -339,6 +339,36 @@ TABLE_FOOTER;
     {
         return strtoupper(trim($value));
     }
+    
+    /**
+     * Returns the LDAP unit id from it's label.
+     */
+    function get_ldap_unit_id($unit_label)
+    {
+        $dn = "o=epfl,c=ch";
+
+        $ds = ldap_connect("ldap.epfl.ch") or die ("Error connecting to LDAP");
+
+        if ($ds === false) {
+          return false;
+        }
+
+        ldap_set_option($ds, LDAP_OPT_PROTOCOL_VERSION, 3);
+
+        $result = ldap_search($ds, $dn, "(&(cn=". $unit_label .")(objectclass=EPFLorganizationalUnit))");
+
+        if ($result === false) {
+          return false;
+        }
+
+        $infos = ldap_get_entries($ds, $result);
+
+        $unit_id = ($infos['count'] > 0) ? $infos[0]['uniqueidentifier'][0]:null;
+
+        ldap_close($ds);
+
+        return $unit_id;
+    }
 }
 
 

--- a/EPFL-Accred.php
+++ b/EPFL-Accred.php
@@ -103,7 +103,7 @@ class Controller
 
         if (empty(trim($user_role)) && $user === false) {
             // User unknown and has no role: die() early (don't create it)
-            header("Location: " . $this->get_403_url());
+            do_action("epfl_accred_403_user_no_role");
             die();
         }
 
@@ -135,23 +135,9 @@ class Controller
         if (empty(trim($user_role))) {
             // User with no role, but exists in database: die late
             // (*after* invalidating their rights in the WP database)
-            header("Location: " . $this->get_403_url());
+            do_action("epfl_accred_403_user_no_role");
             die();
         }
-    }
-    
-    /**
-     * Returns the URL the user is redirect to for a 403 (access denied) error.
-     */
-    function get_403_url()
-    {
-    	$right = "WordPress.Editor";
-    	
-    	$unit_label = $this->settings->get('unit');
-    	
-    	$url = "/global-error/403.php?error_type=accred&right=${right}&unit_label=${unit_label}";
-    
-      return $url;
     }
 }
 

--- a/site.php
+++ b/site.php
@@ -8,6 +8,24 @@ if (! defined('ABSPATH')) {
     die('Access denied.');
 }
 
+add_action("epfl_accred_403_user_no_role", function() {
+    header("Location: " . get_403_url());
+});
+
+/**
+ * Returns the URL the user is redirect to for a 403 (access denied) error.
+ */
+function get_403_url() {
+	
+    $right = "WordPress.Editor";
+	
+    $unit_label = Controller::getInstance()->settings->get('unit');
+	
+    $url = "/global-error/403.php?error_type=accred&right=${right}&unit_label=${unit_label}";
+
+    return $url;
+}
+
 // Controller::getInstance()->is_debug_enabled = true;
 // Controller::getInstance()->settings->is_debug_enabled = true;
 

--- a/site.php
+++ b/site.php
@@ -21,7 +21,7 @@ function get_403_url()
 	
     $unit_label = Controller::getInstance()->settings->get('unit');
 	
-	 $unit_id = Controller::getInstance()->settings->get_ldap_unit_id($unit_label);
+    $unit_id = Controller::getInstance()->settings->get_ldap_unit_id($unit_label);
 	    
     $url = "/global-error/403.php?error_type=accred&right=${right}&unit_id=${unit_id}&unit_label=${unit_label}";
 

--- a/site.php
+++ b/site.php
@@ -15,13 +15,15 @@ add_action("epfl_accred_403_user_no_role", function() {
 /**
  * Returns the URL the user is redirect to for a 403 (access denied) error.
  */
-function get_403_url() {
-	
+function get_403_url()
+{	
     $right = "WordPress.Editor";
 	
     $unit_label = Controller::getInstance()->settings->get('unit');
 	
-    $url = "/global-error/403.php?error_type=accred&right=${right}&unit_label=${unit_label}";
+	 $unit_id = Controller::getInstance()->settings->get_ldap_unit_id($unit_label);
+	    
+    $url = "/global-error/403.php?error_type=accred&right=${right}&unit_id=${unit_id}&unit_label=${unit_label}";
 
     return $url;
 }


### PR DESCRIPTION
In case of access denied, redirect the user to a custom 403 error page, which displays a user friendly message like which role is required in which unit, with a link to the unit's accreditors.

You can see an example here:

https://env-lb-os-exopge.epfl.ch/global-error/403.php?error_type=accred&right=WordPress.Editor&unit_id=10201&unit_label=ENAC