### PR TITLE
To avoid errors if updating unit from WP-CLI and set it in lowercase

### DIFF
--- a/EPFL-Accred.php
+++ b/EPFL-Accred.php
@@ -290,7 +290,7 @@ TABLE_FOOTER;
 
     function get_access_level_from_accred ($tequila_data)
     {
-        $owner_unit = trim($this->get('unit'));
+        $owner_unit = strtoupper(trim($this->get('unit')));
         if (empty($owner_unit)) {
             return null;
         }


### PR DESCRIPTION
On a eu le problème sur quelques sites où le nom de l'unité était incorrect et on l'a mis à jour via WP-CLI mais en minuscules. Du coup, les gens n'ont pas accès car la recherche ne peut pas être faite correctement 
Cette PR permet de corriger le problème de mise à jour via WP-CLI dans le cas où la casse ne serait pas bonne.
Actuellement, c'est forcé en majuscules lors de l'enregistrement de l'option lorsque l'on édite celle-ci via la page de config du plugin mais les modifs via WP-CLI n'ont pas été prises en compte.