### PR TITLE
Fix incorrect adminbar display setting

### DIFF
--- a/EPFL-Accred.php
+++ b/EPFL-Accred.php
@@ -137,7 +137,7 @@ class Controller
         }
 
         /* Hide admin bar if necessary */
-        update_user_meta( $user->ID, 'show_admin_bar_front', !in_array($user_role, $this::HIDE_ADMINBAR_FOR_ROLES));
+        update_user_meta( $user->ID, 'show_admin_bar_front', in_array($user_role, $this::HIDE_ADMINBAR_FOR_ROLES)?'false':'true');
 
         if (empty(trim($user_role))) {
             // User with no role, but exists in database: die late

--- a/EPFL-Accred.php
+++ b/EPFL-Accred.php
@@ -2,7 +2,7 @@
 /*
  * Plugin Name: EPFL Accred
  * Description: Automatically sync access rights to WordPress from EPFL's institutional data repositories
- * Version:     0.11 (vpsi)
+ * Version:     0.12 (vpsi)
  * Author:      Dominique Quatravaux
  * Author URI:  mailto:dominique.quatravaux@epfl.ch
  */


### PR DESCRIPTION
Erreur dans la manière de dire si on doit afficher ou pas la barre d'admin en haut pour les utilisateurs... 
Il ne faut pas passer `true` ou `false` mais `"true"` ou `"false"` (donc sous forme de chaine de caractères)...

C'est ça ce que Laurent tentait d'expliquer en ce matin froid du 20 novembre 2018, jour où notre cher GregLeBarbar n'a pas pu nous rejoindre à cause d'une batterie plate.