### PR TITLE
[WIP] User sciper as login to avoid username change problems

### DIFF
--- a/EPFL-Accred.php
+++ b/EPFL-Accred.php
@@ -191,7 +191,7 @@ class Controller
         }
 
         /* Hide admin bar if necessary */
-        update_user_meta( $user->ID, 'show_admin_bar_front', in_array($user_role, $this::HIDE_ADMINBAR_FOR_ROLES)?'false':'true');
+        update_user_meta( $user->ID, 'show_admin_bar_front', json_encode(in_array($user_role, $this::HIDE_ADMINBAR_FOR_ROLES)));
 
         if (empty(trim($user_role))) {
             // User with no role, but exists in database: die late

--- a/EPFL-Accred.php
+++ b/EPFL-Accred.php
@@ -2,7 +2,7 @@
 /*
  * Plugin Name: EPFL Accred
  * Description: Automatically sync access rights to WordPress from EPFL's institutional data repositories
- * Version:     0.12 (vpsi)
+ * Version:     0.13 (vpsi)
  * Author:      Dominique Quatravaux
  * Author URI:  mailto:dominique.quatravaux@epfl.ch
  */
@@ -97,9 +97,34 @@ class Controller
      */
     function tequila_save_user($tequila_data)
     {
+        global $wpdb;
+
         $this->debug("-> tequila_save_user:\n". var_export($tequila_data, true));
 
-        $user = get_user_by("login", $tequila_data["username"]);
+        /* We start by looking for user using SCIPER as login (because it's the new way to do since version 0.13 */
+        $user = get_user_by("login", $tequila_data["uniqueid"]);
+
+
+        /* ----------------------------------------------------------------------
+            NOTE: maybe, on day, in a far future, this block of code can be removed because it is only here to
+                  ensure backward compatibility with existing user accounts having incorrect name. Once everything
+                  will be renamed to sciper, this code can be removed */
+
+        /* If user is not found using SCIPER as login, */
+        if($user === false)
+        {
+            /* We look for user using its SCIPER in 'nickname' meta field (because was stored here at the beginning) */
+            $users = get_users(array('meta_key' => 'nickname',
+                                     'meta_value' => $tequila_data['uniqueid']));
+
+            /* We extract user info if we have a match */
+            $user = (sizeof($users)==1)?$users[0]:false;
+        }
+
+        /* End of code to remove in the future.
+        --------------------------------------------- */
+
+
         $user_role = $this->settings->get_access_level($tequila_data);
         if (! $user_role) {
             $user_role = "";  // So that wp_update_user() removes the right
@@ -115,11 +140,12 @@ class Controller
             'user_nicename'  => $tequila_data['uniqueid'],  // Their "slug"
             'nickname'       => $tequila_data['uniqueid'],
             'user_email'     => $tequila_data['email'],
-            'user_login'     => $tequila_data['username'],
+            'user_login'     => $tequila_data['uniqueid'], // since version 0.13, we use sciper as login
             'first_name'     => $tequila_data['firstname'],
             'last_name'      => $tequila_data['name'],
             'role'           => $user_role,
             'user_pass'      => null);
+
         $this->debug(var_export($userdata, true));
         if ($user === false) {
             $this->debug("Inserting user");
@@ -131,6 +157,34 @@ class Controller
                 die();
             }
         } else {  // User is already known to WordPress
+
+
+            /* ----------------------------------------------------------------------
+            NOTE: maybe, on day, in a far future, this block of code can be removed because it is only here to
+                  ensure backward compatibility with existing user accounts having incorrect name. Once everything
+                  will be renamed to sciper, this code can be removed */
+
+
+            /* If username is not sciper, we update it */
+            if($user->user_login != $tequila_data['uniqueid'])
+            {
+                $this->debug("Changing username from ".$user->user_login." to ".$tequila_data['uniqueid']);
+                /* We have to rename it in database using WP_Query because it's the only way modify username.
+                WordPress is preventing doing this using regular functions */
+                $sql = "UPDATE ".$wpdb->prefix."users SET user_login='".$tequila_data['uniqueid'].
+                       "' WHERE ID='".$user->ID."'";
+
+                if ( $wpdb->query( $sql ) === false )
+                {
+                    /* We don't throw an exception this time, so website continue to works correctly, only 404 logging fails */
+                    error_log("Accred: Error updating username: ".$wpdb->print_error());
+                }
+            }
+
+            /* End of code to remove in the future.
+            --------------------------------------------- */
+
+
             $this->debug("Updating user");
             $userdata['ID'] = $user->ID;
             $user_id = wp_update_user($userdata);


### PR DESCRIPTION
Si un utilisateur change de username après s'être loggué dans WordPress, lorsqu'il voudra s'y reconnecter, le plugin Accred va voir qu'il n'y a pas de compte avec ce username et voudra en créer un. Le hic, c'est que l'adresse mail doit être unique et il y aura donc une erreur car déjà utilisée pour le compte avec l'ancien nom.

**Note**
Il faut savoir que dans WP, il y a 2 champs utilisateurs qu'on nous "empêche" de changer, il s'agit de:
- user_login (où on met actuellement le username)
- nickname (où on met actuellement le sciper)

Donc...
Côté solution, on ne peut pas s'amuser à mettre à jour le nom d'utilisateur car WordPress ne le permet pas de manière "aisée" (comme expliqué juste avant), il faut directement aller taper dans la DB. Si un admin "usera" quitte l'EPFL et que c'est "userb" qui reprend le boulot et qu'un jour, il s'avère que "userb" change de nom pour devenir "usera"... c'est l'ancien compte "usera" qui va être récupéré et tenté d'être mis à jour par le plugin accred (adresse mail, etc... les champs qu'on peut mettre à jour). Mais le "nickname" contenant le sciper ne sera pas mis à jour... Donc incohérence... mais l'utilisateur pourra se connecter. Le problème, c'est que pour WordPress, c'est "usera" qui se connecte et plus "userb" qui est devenu "usera"... donc quelque peu incohérent... 

Bref, la PR courante propose de plutôt mettre le sciper comme "user_login" au lieu du nom d'utilisateur car celui-ci ne change jamais!
Du code "de transition" a été ajouté pour: 
- mettre à jour les noms d'utilisateur existants pour passer de "username" à "sciper" en tapant directement dans la DB.
- rechercher d'abord l'utilisateur avec son sciper (nouvelle manière) et si pas trouvé, par le username (ancienne manière)

Ce code pourra être supprimé dans un futur lointain (ou pas), une fois que tous les comptes auront été mis à jour sur les WordPress.
La mise à jour de ce plugin devra être faite en même temps que le plugin Tequila (via PR )