### PR TITLE
Customize 'access denied' error on inside website for unauthorized visitors

### DIFF
--- a/EPFL-Accred.php
+++ b/EPFL-Accred.php
@@ -2,7 +2,7 @@
 /*
  * Plugin Name: EPFL Accred
  * Description: Automatically sync access rights to WordPress from EPFL's institutional data repositories
- * Version:     0.12 (vpsi)
+ * Version:     0.13 (vpsi)
  * Author:      Dominique Quatravaux
  * Author URI:  mailto:dominique.quatravaux@epfl.ch
  */

--- a/site.php
+++ b/site.php
@@ -16,14 +16,19 @@ add_action("epfl_accred_403_user_no_role", function() {
  * Returns the URL the user is redirect to for a 403 (access denied) error.
  */
 function get_403_url()
-{	
+{
+    /* Redirecting to correct error page:
+     "accred" -> if trying to access wp-admin page
+     "inside" -> if trying to access public page on website */
+    $error_type = (preg_match('#/wp-admin/#' , $_REQUEST['redirect_to'])===1)?"accred":"inside";
+
     $right = "WordPress.Editor";
 	
     $unit_label = Controller::getInstance()->settings->get('unit');
 	
     $unit_id = Controller::getInstance()->settings->get_ldap_unit_id($unit_label);
 	    
-    $url = "/global-error/403.php?error_type=accred&right=${right}&unit_id=${unit_id}&unit_label=${unit_label}";
+    $url = "/global-error/403.php?error_type=${error_type}&right=${right}&unit_id=${unit_id}&unit_label=${unit_label}";
 
     return $url;
 }


### PR DESCRIPTION
En cas de refus d'accès (car permissions insuffisantes), ajout d'un check pour voir si l'accès demandé sur `/wp-admin/` (admin) ou pas (visiteur). Ceci permet de rediriger sur la page d'erreur adaptée ("accred" ou "inside"), avec un message d'erreur adapté au contexte.

La PR https://github.com/epfl-idevelop/wp-ops/pull/38 ajoute une page d'erreur spécifique aux accès refusés sur les sites insides
