### PR TITLE
Handle username change

### DIFF
--- a/EPFL-Accred.php
+++ b/EPFL-Accred.php
@@ -63,7 +63,7 @@ class Controller
 
     static $instance = false;
     var $settings = null;
-    var $is_debug_enabled = true;
+    var $is_debug_enabled = false;
 
     function debug ($msg)
     {

--- a/EPFL-Accred.php
+++ b/EPFL-Accred.php
@@ -147,12 +147,6 @@ class Controller
 
             $userdata['ID'] = $user->ID;
             $user_id = wp_update_user($userdata);
-
-            if (is_wp_error( $user_id ) ) {
-                $this->debug("User update error: ".$user_id->get_error_message());
-                echo $user_id->get_error_message();
-                die();
-            }
         }
 
         /* Hide admin bar if necessary */

--- a/EPFL-Accred.php
+++ b/EPFL-Accred.php
@@ -101,7 +101,6 @@ class Controller
 
         // Getting by slug (this is where we store uniqueid, which never change)
         $user = get_user_by("slug", $tequila_data["uniqueid"]);
-        $this->debug("--> User in DB: ". var_export($user, true));
         $user_role = $this->settings->get_access_level($tequila_data);
         if (! $user_role) {
             $user_role = "";  // So that wp_update_user() removes the right
@@ -129,7 +128,6 @@ class Controller
             if ( ! is_wp_error( $new_user_id ) ) {
                 $user = new \WP_User($new_user_id);
             } else {
-                $this->debug("User insert error: ". $new_user_id->get_error_message());
                 echo $new_user_id->get_error_message();
                 die();
             }


### PR DESCRIPTION
Permettrait de corriger INC0365445

- Utilisation du sciper pour récupérer un utilisateur dans la DB (vu qu'on enregistre le sciper dans le `user_nicename`... qui est égal au `slug` en fait). ça permet de retrouver l'utilisateur avec le données Tequila quand son username change.
- Mise à jour du username (`user_login`) dans la DB à l'aide d'une requête et non pas de `wp_update_user` car cette dernière fonction n'arrive pas à gérer le renommage de nom d'utilisateur... et en plus, elle ajoute un `-2` à la fin du `user_nicename` (donc le sciper) et du coup, ça rend la recherche par sciper inefficace vu que plus rien n'est trouvé...
